### PR TITLE
Update CentOS 7.9 box

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ For using this setup, you will need to do a couple of things first to ensure
 that everything will run smoothly.
 
 First, you need to install [packer](https://learn.hashicorp.com/tutorials/packer/get-started-install-cli), as it is the main application needed to generate the builds.
+Also install packer [QEMU plugin](https://developer.hashicorp.com/packer/integrations/hashicorp/qemu) and 
+[Vagrant plugin](https://developer.hashicorp.com/packer/integrations/hashicorp/vagrant) needed for building vagrant boxes.
 
 If you don't have `libvirt` installed, you can follow this guide on [fedora project](https://developer.fedoraproject.org/tools/virtualization/installing-libvirt-and-virt-install-on-fedora-linux.html) to install it.
 
@@ -52,3 +54,27 @@ can do so by setting an environment variable before running the script, like:
 This will append the `-var="headless=false"` to the list of packer variables
 that will be passed to the build. Any variable defined in both `centos.pkr.hcl`
 and `ol.pkr.hcl` can be overrided like that.
+
+
+## Testing the box
+The `./build <system_version>` should build `.box` file in the root of this repo. 
+If you decide to test it locally, you need to add the box to the vagrant library,
+prepare Vagrant file with UEFI support and run the box.
+
+1. Add to vagrant library
+In the root folder, run:
+```
+vagrant box add ./<name_of_the_box>.box --name=<your_selected_name>
+```
+2. Prepare Vagrant file
+In some another folder (e.g. `/tmp/vagrant-test`) run `Vagrant init`
+and change content of the generated `Vagrantfile` to (or create the
+file direcly) to contain:
+```
+Vagrant.configure("2") do |config|
+  config.vm.box = "<your_selected_name>"
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.loader = "/usr/share/edk2/ovmf/OVMF_CODE.fd"
+  end
+end
+```

--- a/centos.pkr.hcl
+++ b/centos.pkr.hcl
@@ -75,7 +75,7 @@ source "qemu" "centos-79-uefi" {
   format           = "qcow2"
   http_directory   = "http"
   iso_checksum     = "sha256:b79079ad71cc3c5ceb3561fff348a1b67ee37f71f4cddfec09480d4589c191d6"
-  iso_url          = "http://packages.oit.ncsu.edu/centos/7.9.2009/isos/x86_64/CentOS-7-x86_64-NetInstall-2009.iso"
+  iso_url          = "https://vault.centos.org/7.9.2009/isos/x86_64/CentOS-7-x86_64-NetInstall-2009.iso"
   machine_type     = "q35"
   firmware         = "${var.firmware}"
   use_pflash       = false

--- a/http/centos79-ks.cfg
+++ b/http/centos79-ks.cfg
@@ -4,7 +4,9 @@
 eula --agreed
 
 # Use network installation
-url --url="http://mirror.centos.org/centos/7/os/x86_64/"
+url --url="http://vault.centos.org/centos/7/os/x86_64/"
+repo --name="base" --baseurl=http://vault.centos.org/7.9.2009/os/x86_64
+repo --name="updates" --baseurl=http://vault.centos.org/7.9.2009/updates/x86_64
 
 # Peform installation
 text
@@ -158,6 +160,12 @@ dracut -f /boot/initramfs-${KERNEL_VERSION}.img ${KERNEL_VERSION}
 
 grub2-install --target=x86_64-efi --efi-directory=/boot/efi --boot-directory=/boot/efi/EFI
 grub2-mkconfig -o /boot/grub2/grub.cfg
+
+# Fix the repos to point to vault after Jul 30
+sed -i '/^mirrorlist=/s/^/#/' /etc/yum.repos.d/CentOS-Base.repo
+sed -i 's|^#baseurl=http://mirror.centos.org/|baseurl=http://vault.centos.org/|' /etc/yum.repos.d/CentOS-Base.repo
+mv /etc/yum.repos.d/CentOS-Base.repo /etc/yum.repos.d/CentOS-Vault-Base.repo
+find /etc/yum.repos.d/ -maxdepth 1 -name "CentOS*" ! -name "CentOS-Vault-Base.repo" -exec rm -f {} \;
 
 # Cleanup
 yum clean all


### PR DESCRIPTION
Update CentOS 7.9 to contain latest versions of packages and change the repositories to point to vault even after box creation.